### PR TITLE
Restore source for dependencies installation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,2 @@
+source "https://rubygems.org"
 gem "github-pages", "~> 212", group: :jekyll_plugins


### PR DESCRIPTION
`bundle install` does not work without it